### PR TITLE
CRDCDH-622 Fix download Dropdown text wrap

### DIFF
--- a/src/components/ModelNavigator/DataDictionary/Header/components/download-dropdown-menu.js
+++ b/src/components/ModelNavigator/DataDictionary/Header/components/download-dropdown-menu.js
@@ -271,7 +271,7 @@ const styles = () => ({
     }
   },
   availableDownloadDropdownBtn: {
-    width: '258px',
+    minWidth: '258px',
     height: '38px',
     backgroundColor: '#F2F2F2'
   },


### PR DESCRIPTION
### Overview

This PR allows for dynamic width of the "Available Downloads" button to avoid text wrap of long selections. 

**NOTE:** This modified behavior may not be ideal for ICDC, we can create a separate release branch if desired.

#### Observed behavior:

<img width="521" alt="Screenshot 2023-12-01 at 9 54 43 AM" src="https://github.com/CBIIT/Data-Model-Navigator/assets/38357871/d6fba774-f066-4c3a-a9bf-731f90bd62a8">

<img width="521" alt="Screenshot 2023-12-01 at 9 54 48 AM" src="https://github.com/CBIIT/Data-Model-Navigator/assets/38357871/53c9f4b4-f845-4b78-b630-e84c08729cdf">

#### Modified behavior:

<img width="521" alt="Screenshot 2023-12-01 at 9 56 16 AM" src="https://github.com/CBIIT/Data-Model-Navigator/assets/38357871/d9308648-f2ca-42dc-a587-39ea1518ef37">

<img width="521" alt="Screenshot 2023-12-01 at 9 56 21 AM" src="https://github.com/CBIIT/Data-Model-Navigator/assets/38357871/e02badf0-9606-4121-8aee-b8b0c5ef3833">

### Change Details (Specifics)

- Change `width` CSS property on Available Downloads to `min-width`

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/CRDCDH-622