### PR TITLE
CRDCDH-2260 Add Release Notes tab

### DIFF
--- a/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.component.js
+++ b/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.component.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { withStyles } from "@material-ui/core";
+import Markdown from "react-markdown";
+import styles from "./Changelog.style";
+import { useSelector } from "react-redux";
+
+const ChangelogComponent = ({ classes }) => {
+  const changelogMD = useSelector(
+    (state) => state.changelogInfo && state.changelogInfo.mdData
+  );
+
+  return (
+    <div className={classes.markdownBox}>
+      {changelogMD ? (
+        <Markdown>{changelogMD}</Markdown>
+      ) : (
+        <div className={classes.error}>
+          An error occurred while loading the Release Notes
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default withStyles(styles)(ChangelogComponent);
+

--- a/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.controller.js
+++ b/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.controller.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ChangelogComponent from './Changelog.component';
+import { useSelector } from "react-redux";
+
+const ChangelogController = () => {
+  const changelogMD = useSelector(
+    (state) => state.changelogInfo && state.changelogInfo.mdData
+  );
+
+  if (!changelogMD) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <ChangelogComponent />
+    </>
+  );
+};
+
+export default ChangelogController;

--- a/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.style.js
+++ b/src/components/ModelNavigator/DataDictionary/Changelog/Changelog.style.js
@@ -1,0 +1,17 @@
+export default () => ({
+  markdownBox: {
+    fontFamily: "Nunito",
+    color: "rgba(0, 0, 0, 0.87)",
+    borderRadius: "6px",
+    background: "#fff",
+    position: "relative",
+    padding: "6px 72px",
+    "& > h1:first-of-type": {
+      textAlign: "center",
+    },
+  },
+  error: {
+    marginTop: "20px",
+    marginBottom: "20px",
+  },
+});

--- a/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
+++ b/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
@@ -123,7 +123,7 @@ const DictionaryView = ({
 const mapStateToProps = (state) => {
   return {
     graphView: state.ddgraph.isGraphView,
-    changelogMD: state.changelogInfo.mdData
+    changelogMD: state.changelogInfo?.mdData
   };
 };
 

--- a/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
+++ b/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
@@ -31,7 +31,7 @@ const DictionaryView = ({
   handleClearSearchResult,
   dictionary,
   graphView,
-  changelogMD,
+  changelogInfo,
   onSetGraphView,
   onWidthChange,
 }) => {
@@ -46,9 +46,9 @@ const DictionaryView = ({
     onWidthChange(ref.current.offsetWidth);
   };
 
-  const dynamicTabItems = changelogMD ? [...tabItems, {
+  const dynamicTabItems = changelogInfo?.mdData ? [...tabItems, {
     index: 2,
-    label: "Release Notes",
+    label: changelogInfo.tabName,
     value: "release_notes_view",
   }] : tabItems;
 
@@ -123,7 +123,7 @@ const DictionaryView = ({
 const mapStateToProps = (state) => {
   return {
     graphView: state.ddgraph.isGraphView,
-    changelogMD: state.changelogInfo?.mdData
+    changelogInfo: state.changelogInfo,
   };
 };
 

--- a/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
+++ b/src/components/ModelNavigator/DataDictionary/DictionaryView/DictionaryView.jsx
@@ -2,12 +2,14 @@ import React, { useState, useRef, useLayoutEffect, useEffect } from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { withStyles } from "@material-ui/core";
+import { useSelector } from "react-redux";
 import Styles from "./DictionaryStyle";
 import Tab from "./Tab/Tab";
 import TabPanel from "./Tab/TabPanel";
 import TabThemeProvider from "./Tab/TabThemeConfig";
 import ReduxDataDictionaryTable from "../Table/DataDictionaryTable";
 import CanvasView from "../ReactFlowGraph/Canvas/CanvasController";
+import ChangelogView from "../Changelog/Changelog.controller";
 import { setCanvasWidth, setGraphView } from "../Store/actions/graph";
 
 const tabItems = [
@@ -29,6 +31,7 @@ const DictionaryView = ({
   handleClearSearchResult,
   dictionary,
   graphView,
+  changelogMD,
   onSetGraphView,
   onWidthChange,
 }) => {
@@ -42,6 +45,12 @@ const DictionaryView = ({
     setTabViewWidth(ref.current.offsetWidth);
     onWidthChange(ref.current.offsetWidth);
   };
+
+  const dynamicTabItems = changelogMD ? [...tabItems, {
+    index: 2,
+    label: "Release Notes",
+    value: "release_notes_view",
+  }] : tabItems;
 
   useEffect(() => {
     onWidthChange(ref.current.offsetWidth);
@@ -75,7 +84,7 @@ const DictionaryView = ({
           <div className={classes.tabItems}>
             <Tab
               styleClasses={classes}
-              tabItems={tabItems}
+              tabItems={dynamicTabItems}
               currentTab={currentTab}
               handleTabChange={handleTabChange}
             />
@@ -98,6 +107,11 @@ const DictionaryView = ({
                   />
                 </div>
               </TabPanel>
+              <TabPanel value={currentTab} index={tabItems?.length || 0}>
+                <div className={classes.changelogView}>
+                  <ChangelogView />
+                </div>
+              </TabPanel>
             </div>
           </div>
         </div>
@@ -109,6 +123,7 @@ const DictionaryView = ({
 const mapStateToProps = (state) => {
   return {
     graphView: state.ddgraph.isGraphView,
+    changelogMD: state.changelogInfo.mdData
   };
 };
 

--- a/src/components/ModelNavigator/DataDictionary/ReadMe/ReadMe.style.js
+++ b/src/components/ModelNavigator/DataDictionary/ReadMe/ReadMe.style.js
@@ -1,9 +1,12 @@
 export default () => ({
   dialogBox: {
-    minWidth: "750px",
     overflowY: "scroll",
   },
   dialogPaper: {
+    width: "1500px",
+    height: "750px",
+    maxWidth: "80%",
+    maxHeight: "85%",
     paddingBottom: "10px",
   },
   titleContent: {

--- a/src/components/ModelNavigator/DataDictionary/Service/Dictionary.jsx
+++ b/src/components/ModelNavigator/DataDictionary/Service/Dictionary.jsx
@@ -214,3 +214,30 @@ export async function getModelExploreData(...urls) {
     },
   };
 }
+
+/**
+ * Retrieves the changelog (Markdown) from the specified URL.
+ *
+ * @param {string} url - The URL to fetch the changelog from
+ * @returns {Promise<string | null>} - The retrieved Markdown string, or null if invalid
+ */
+export const getChangelog = async (url) => {
+  if (typeof url !== 'string' || !url?.trim()?.length) {
+    console.error('Invalid or empty changelog URL provided.');
+    return null;
+  }
+
+  try {
+    const response = await axios.get(url);
+
+    if (typeof response?.data !== 'string' || !response?.data?.trim()?.length) {
+      console.error('Changelog response is empty or not in the expected format.')
+      return null;
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch changelog:', error);
+    return null;
+  }
+};

--- a/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
@@ -396,4 +396,16 @@ const versionInfo = (state = {}, action) => {
   }
 };
 
-export { ddgraph, versionInfo };
+const changelogInfo = (state = {}, action) => {
+  switch (action.type) {
+    case 'RECEIVE_CHANGELOG_INFO':
+      return {
+        ...state,
+        mdData: action.data || undefined,
+      };
+    default:
+      return state;
+  }
+};
+
+export { ddgraph, versionInfo, changelogInfo };

--- a/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
@@ -401,7 +401,8 @@ const changelogInfo = (state = {}, action) => {
     case 'RECEIVE_CHANGELOG_INFO':
       return {
         ...state,
-        mdData: action.data || undefined,
+        mdData: action.data.changelogMD || undefined,
+        tabName: action.data.changelogTabName || "Version History",
       };
     default:
       return state;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // export { default as Header } from './components/headers';
 export { default as ReduxDataDictionary } from './components/ModelNavigator/DataDictionary/ReduxDataDictionary';
 // export { default as ModelExplorer } from './components/DataDictionaryComponent/dictionaryController';
-export { ddgraph as ddgraph, versionInfo as versionInfo } from './components/ModelNavigator/DataDictionary/Store/reducers/graph';
+export { ddgraph as ddgraph, versionInfo as versionInfo, changelogInfo as changelogInfo } from './components/ModelNavigator/DataDictionary/Store/reducers/graph';
 export { moduleReducers as moduleReducers} from './components/ModelNavigator/DataDictionary/Store/reducers/filter';
 export { getModelExploreData } from './components/ModelNavigator/DataDictionary/Service/Dictionary';

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,4 @@ export { default as ReduxDataDictionary } from './components/ModelNavigator/Data
 // export { default as ModelExplorer } from './components/DataDictionaryComponent/dictionaryController';
 export { ddgraph as ddgraph, versionInfo as versionInfo, changelogInfo as changelogInfo } from './components/ModelNavigator/DataDictionary/Store/reducers/graph';
 export { moduleReducers as moduleReducers} from './components/ModelNavigator/DataDictionary/Store/reducers/filter';
-export { getModelExploreData } from './components/ModelNavigator/DataDictionary/Service/Dictionary';
+export { getModelExploreData, getChangelog } from './components/ModelNavigator/DataDictionary/Service/Dictionary';

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,4 @@ export { default as ReduxDataDictionary } from './components/ModelNavigator/Data
 // export { default as ModelExplorer } from './components/DataDictionaryComponent/dictionaryController';
 export { ddgraph as ddgraph, versionInfo as versionInfo, changelogInfo as changelogInfo } from './components/ModelNavigator/DataDictionary/Store/reducers/graph';
 export { moduleReducers as moduleReducers} from './components/ModelNavigator/DataDictionary/Store/reducers/filter';
-export { getModelExploreData, getChangelog } from './components/ModelNavigator/DataDictionary/Service/Dictionary';
+export { getChangelog as getChangelog, getModelExploreData } from './components/ModelNavigator/DataDictionary/Service/Dictionary';

--- a/src/stories/ModelNavigator.js
+++ b/src/stories/ModelNavigator.js
@@ -10,7 +10,7 @@ import { moduleReducers as submission } from '../components/ModelNavigator/DataD
 // import store from './store';
 import ReduxDataDictionary from '../components/ModelNavigator/DataDictionary/ReduxDataDictionary';
 import { filterConfig } from '../components/ModelNavigator/bento/dataDictionaryData';
-import { getModelExploreData } from '../components/ModelNavigator/DataDictionary/Service/Dictionary';
+import { getChangelog, getModelExploreData } from '../components/ModelNavigator/DataDictionary/Service/Dictionary';
 
 const pdfDownloadConfig = {
   fileType: 'pdf',
@@ -93,17 +93,13 @@ function buildStore() {
 
 async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl = "") {
   const response = await getModelExploreData(modelUrl, propsUrl)?.catch((e) => { console.log(e); return null; });
-  
-  let changelogDataResponse = null;
-  if (changelogUrl?.trim()?.length > 0) {
-    changelogDataResponse = await axios.get(changelogUrl)?.catch((e) => { console.log(e); return null; });
-  }
+  const changelogMD = await getChangelog(changelogUrl)?.catch((e) => { console.log(e); return null; });
   
   if (!response?.data || !response?.version) {
     throw new Error('Failed to fetch data');
   }
 
-  if (!changelogDataResponse?.data) {
+  if (!changelogMD) {
     // Shouldn't be a blocker
     console.error('Failed to fetch changelog data');
   }
@@ -133,11 +129,11 @@ async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl =
     }),
   ];
 
-  if (changelogDataResponse?.data) {
+  if (changelogMD?.length > 0) {
     dispatches.push(
       store.dispatch({
         type: 'RECEIVE_CHANGELOG_INFO',
-        data: changelogDataResponse.data,
+        data: changelogMD,
       })
     );
   }

--- a/src/stories/ModelNavigator.js
+++ b/src/stories/ModelNavigator.js
@@ -21,11 +21,6 @@ const pdfDownloadConfig = {
   footnote: 'test',
 };
 
-const readMeConfig = {
-  readMeUrl: 'https://raw.githubusercontent.com/rana22/category_partition/main/README.md',
-  readMeTitle: 'Understanding the ICDC Data Model',
-};
-
 const assetConfig = {
   iconUrl: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/data_model_pdf_icons/icdc/DMN/'
 }
@@ -91,7 +86,7 @@ function buildStore() {
   return store;
 }
 
-async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl = "") {
+async function populateStore(store, modelUrl = "", propsUrl = "", readMeUrl = "", changelogUrl = "") {
   const response = await getModelExploreData(modelUrl, propsUrl)?.catch((e) => { console.log(e); return null; });
   const changelogMD = await getChangelog(changelogUrl)?.catch((e) => { console.log(e); return null; });
   
@@ -110,7 +105,10 @@ async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl =
       payload: {
         data: response.data,
         facetfilterConfig: filterConfig,
-        readMeConfig: readMeConfig,
+        readMeConfig: {
+          readMeUrl,
+          readMeTitle: "Understanding the Data Model",
+        },
         graphViewConfig: graphViewConfig,
         pdfDownloadConfig: pdfDownloadConfig,
         assetConfig: assetConfig,
@@ -133,7 +131,10 @@ async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl =
     dispatches.push(
       store.dispatch({
         type: 'RECEIVE_CHANGELOG_INFO',
-        data: changelogMD,
+        data: {
+          changelogMD,
+          changelogTabName: "Version History"
+        },
       })
     );
   }
@@ -141,15 +142,15 @@ async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl =
   await Promise.all(dispatches);
 }
 
-const ModelNavigator = ({ modelUrl, propsUrl, changelogUrl }) => {
+const ModelNavigator = ({ modelUrl, propsUrl, readMeUrl, changelogUrl }) => {
   const [store, setStore] = React.useState(buildStore());
 
   useEffect(() => {
     const newStore = buildStore();
 
     setStore(newStore);
-    populateStore(newStore, modelUrl, propsUrl, changelogUrl);
-  }, [modelUrl, propsUrl, changelogUrl]);
+    populateStore(newStore, modelUrl, propsUrl, readMeUrl, changelogUrl);
+  }, [modelUrl, propsUrl, changelogUrl, readMeUrl]);
 
   return (
     <Provider store={store}>

--- a/src/stories/ModelNavigator.js
+++ b/src/stories/ModelNavigator.js
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
+import axios from 'axios';
 import { Provider } from 'react-redux';
 import _ from 'lodash';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import ReduxThunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
-import { ddgraph, versionInfo } from '../components/ModelNavigator/DataDictionary/Store/reducers/graph';
+import { ddgraph, versionInfo, changelogInfo } from '../components/ModelNavigator/DataDictionary/Store/reducers/graph';
 import { moduleReducers as submission } from '../components/ModelNavigator/DataDictionary/Store/reducers/filter';
 // import store from './store';
 import ReduxDataDictionary from '../components/ModelNavigator/DataDictionary/ReduxDataDictionary';
@@ -71,6 +72,7 @@ function buildStore() {
   const reducers = {
     ddgraph,
     versionInfo,
+    changelogInfo,
     submission,
   };
 
@@ -89,49 +91,69 @@ function buildStore() {
   return store;
 }
 
-async function populateStore(store, modelUrl = "", propsUrl = "") {
+async function populateStore(store, modelUrl = "", propsUrl = "", changelogUrl = "") {
   const response = await getModelExploreData(modelUrl, propsUrl)?.catch((e) => { console.log(e); return null; });
+  
+  let changelogDataResponse = null;
+  if (changelogUrl?.trim()?.length > 0) {
+    changelogDataResponse = await axios.get(changelogUrl)?.catch((e) => { console.log(e); return null; });
+  }
+  
   if (!response?.data || !response?.version) {
     throw new Error('Failed to fetch data');
   }
 
-  Promise.all(
-    [
-      store.dispatch({
-        type: 'RECEIVE_DICTIONARY',
-        payload: {
-          data: response.data,
-          facetfilterConfig: filterConfig,
-          readMeConfig: readMeConfig,
-          graphViewConfig: graphViewConfig,
-          pdfDownloadConfig: pdfDownloadConfig,
-          assetConfig: assetConfig,
-        },
-      }),
-      store.dispatch({
-        type: 'REACT_FLOW_GRAPH_DICTIONARY',
-        dictionary: response.data,
+  if (!changelogDataResponse?.data) {
+    // Shouldn't be a blocker
+    console.error('Failed to fetch changelog data');
+  }
+
+  const dispatches = [
+    store.dispatch({
+      type: 'RECEIVE_DICTIONARY',
+      payload: {
+        data: response.data,
+        facetfilterConfig: filterConfig,
+        readMeConfig: readMeConfig,
+        graphViewConfig: graphViewConfig,
         pdfDownloadConfig: pdfDownloadConfig,
         assetConfig: assetConfig,
-        graphViewConfig: graphViewConfig,
-      }),
+      },
+    }),
+    store.dispatch({
+      type: 'REACT_FLOW_GRAPH_DICTIONARY',
+      dictionary: response.data,
+      pdfDownloadConfig: pdfDownloadConfig,
+      assetConfig: assetConfig,
+      graphViewConfig: graphViewConfig,
+    }),
+    store.dispatch({
+      type: 'RECEIVE_VERSION_INFO',
+      data: response.version,
+    }),
+  ];
+
+  if (changelogDataResponse?.data) {
+    dispatches.push(
       store.dispatch({
-        type: 'RECEIVE_VERSION_INFO',
-        data: response.version,
-      }),
-    ],
-  );
+        type: 'RECEIVE_CHANGELOG_INFO',
+        data: changelogDataResponse.data,
+      })
+    );
+  }
+
+  await Promise.all(dispatches);
 }
 
-const ModelNavigator = ({ modelUrl, propsUrl }) => {
+const ModelNavigator = ({ modelUrl, propsUrl, changelogUrl }) => {
   const [store, setStore] = React.useState(buildStore());
 
   useEffect(() => {
     const newStore = buildStore();
 
     setStore(newStore);
-    populateStore(newStore, modelUrl, propsUrl);
-  }, [modelUrl, propsUrl]);
+    populateStore(newStore, modelUrl, propsUrl, changelogUrl);
+  }, [modelUrl, propsUrl, changelogUrl]);
 
   return (
     <Provider store={store}>

--- a/src/stories/ModelNavigator.stories.jsx
+++ b/src/stories/ModelNavigator.stories.jsx
@@ -16,6 +16,11 @@ export default {
         type: 'text',
       },
     },
+    changelogUrl: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 };
 
@@ -47,5 +52,6 @@ export const Navigator = Template.bind({});
 Navigator.args = {
   modelUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/cds-model.yml",
   propsUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/cds-model-props.yml",
+  changelogUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/release-notes.md",
 };
 

--- a/src/stories/ModelNavigator.stories.jsx
+++ b/src/stories/ModelNavigator.stories.jsx
@@ -16,6 +16,11 @@ export default {
         type: 'text',
       },
     },
+    readMeUrl: {
+      control: {
+        type: 'text',
+      }
+    },
     changelogUrl: {
       control: {
         type: 'text',
@@ -52,6 +57,7 @@ export const Navigator = Template.bind({});
 Navigator.args = {
   modelUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/cds-model.yml",
   propsUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/cds-model-props.yml",
+  readMeUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/README.md",
   changelogUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/5.0.4/release-notes.md",
 };
 


### PR DESCRIPTION
### Overview

Added support for displaying Release Notes as a tab using markdown.

### Change Details (Specifics)

- Added new dynamic tab "Release Notes" that is displayed when the changelog is available
- Added reducer to support updating the changelog in state
- Updated Storybook to support changing the `changelogUrl`
- Created component for displaying the markdown changelog (Modeled after CRDCDH)

### Related Ticket(s)

[CRDCDH-2260](https://tracker.nci.nih.gov/browse/CRDCDH-2260) (Task)
[CRDCDH-2231](https://tracker.nci.nih.gov/browse/CRDCDH-2231) (US)