### PR TITLE
DMN-16 Configure pdf download visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-model-navigator",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "data-model-navigator",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-model-navigator",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "",
   "main": "lib/index.js",
   "private": false,

--- a/src/components/ModelNavigator/DataDictionary/Header/Header.component.js
+++ b/src/components/ModelNavigator/DataDictionary/Header/Header.component.js
@@ -95,14 +95,16 @@ const HeaderComponent = ({
                 README
               </Button>
             )}
-            <DownloadDropdownMenu
-              config={{ ...pdfDownloadConfig, type: 'document' }}
-              filteredDictionary={dictionary}
-              fullDictionary={fullDictionary}
-              readMeContent={content}
-              readMeConfig={config}
-              loadingExampleConfig={loadingExampleConfig}
-            />
+            {pdfDownloadConfig.enabled && (
+              <DownloadDropdownMenu
+                config={{ ...pdfDownloadConfig, type: 'document' }}
+                filteredDictionary={dictionary}
+                fullDictionary={fullDictionary}
+                readMeContent={content}
+                readMeConfig={config}
+                loadingExampleConfig={loadingExampleConfig}
+              />
+            )}
           </div>
           <ReadMeComponent
             content={content}

--- a/src/components/ModelNavigator/DataDictionary/ReduxDataDictionary.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReduxDataDictionary.jsx
@@ -17,6 +17,7 @@ const ReduxDataDictionary = (props) => {
 const mapStateToProps = (state) => ({
   isGraphView: state.ddgraph.isGraphView,
   dictionary: state.submission.dictionary,
+  pdfDownloadConfig: state.ddgraph.pdfDownloadConfig,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import {
   getSearchHistoryItems,
   clearSearchHistoryItems,
@@ -35,7 +36,7 @@ const ddgraphInitialState = {
   highlightingMatchedNodeID: null,
   highlightingMatchedNodeOpened: false,
   dictionary: {},
-  pdfDownloadConfig: {},
+  pdfDownloadConfig: { enabled: true },
 };
 
 const ddgraph = (state = ddgraphInitialState, action) => {
@@ -125,7 +126,7 @@ const ddgraph = (state = ddgraphInitialState, action) => {
       return {
         ...state,
         dictionary: action.dictionary,
-        pdfDownloadConfig: action.pdfDownloadConfig,
+        pdfDownloadConfig: merge({}, state.pdfDownloadConfig, action.pdfDownloadConfig),
         graphConfig: action.graphConfig,
         assetConfig: action.assetConfig,
         graphViewConfig: {...action.graphViewConfig, ...state.graphViewConfig},

--- a/src/components/ModelNavigator/DataDictionary/Table/DataDictionaryNode/components/NodeViewComponent.js
+++ b/src/components/ModelNavigator/DataDictionary/Table/DataDictionaryNode/components/NodeViewComponent.js
@@ -127,23 +127,25 @@ const NodeViewComponent = ({
                 )}
               </div>
             </div>
-            <div style={{ paddingRight: "10px" }} onClick={(e) => e.stopPropagation()}>
-              <ButtonGroup className={classes.exportButtonGroup}>
-                {(isTemplate || (isManifest && isTemplate)) && (
-                  <TemplateButton
-                    documentData={node}
-                    isFileManifest={isManifest}
-                    fileName={
-                      isManifest
-                        ? createFileName(
-                          node.id,
-                          pdfDownloadConfig?.fileTransferManifestName || pdfDownloadConfig.downloadPrefix || fileManifestDownloadSettings.filename_prefix, modelVersion, true)
-                        : createFileName(node.id, csvBtnDownloadConfig.prefix, modelVersion, true)
-                    }
-                  />
-                )}
-                <DictionaryButton config={{ pdfDownloadConfig }} documentData={node} />
-              </ButtonGroup>
+            <div style={{ paddingRight: "10px", minWidth: "264px" }} onClick={(e) => e.stopPropagation()}>
+              {pdfDownloadConfig.enabled && (
+                <ButtonGroup className={classes.exportButtonGroup}>
+                  {(isTemplate || (isManifest && isTemplate)) && (
+                    <TemplateButton
+                      documentData={node}
+                      isFileManifest={isManifest}
+                      fileName={
+                        isManifest
+                          ? createFileName(
+                            node.id,
+                            pdfDownloadConfig?.fileTransferManifestName || pdfDownloadConfig.downloadPrefix || fileManifestDownloadSettings.filename_prefix, modelVersion, true)
+                          : createFileName(node.id, csvBtnDownloadConfig.prefix, modelVersion, true)
+                      }
+                    />
+                  )}
+                  <DictionaryButton config={{ pdfDownloadConfig }} documentData={node} />
+                </ButtonGroup>
+              )}
             </div>
           </div>
         </div>

--- a/src/stories/ModelNavigator.js
+++ b/src/stories/ModelNavigator.js
@@ -19,6 +19,7 @@ const pdfDownloadConfig = {
   fileTransferManifestName: "CDS_Data_Loading_Template-file-manifest",
   landscape: 'true',
   footnote: 'test',
+  enabled: false,
 };
 
 const assetConfig = {
@@ -86,7 +87,7 @@ function buildStore() {
   return store;
 }
 
-async function populateStore(store, modelUrl = "", propsUrl = "", readMeUrl = "", changelogUrl = "") {
+async function populateStore(store, modelUrl = "", propsUrl = "", readMeUrl = "", changelogUrl = "", pdfDownloadEnabled = true) {
   const response = await getModelExploreData(modelUrl, propsUrl)?.catch((e) => { console.log(e); return null; });
   const changelogMD = await getChangelog(changelogUrl)?.catch((e) => { console.log(e); return null; });
   
@@ -110,14 +111,14 @@ async function populateStore(store, modelUrl = "", propsUrl = "", readMeUrl = ""
           readMeTitle: "Understanding the Data Model",
         },
         graphViewConfig: graphViewConfig,
-        pdfDownloadConfig: pdfDownloadConfig,
+        pdfDownloadConfig: { ...pdfDownloadConfig, enabled: pdfDownloadEnabled },
         assetConfig: assetConfig,
       },
     }),
     store.dispatch({
       type: 'REACT_FLOW_GRAPH_DICTIONARY',
       dictionary: response.data,
-      pdfDownloadConfig: pdfDownloadConfig,
+      pdfDownloadConfig: { ...pdfDownloadConfig, enabled: pdfDownloadEnabled },
       assetConfig: assetConfig,
       graphViewConfig: graphViewConfig,
     }),
@@ -142,19 +143,19 @@ async function populateStore(store, modelUrl = "", propsUrl = "", readMeUrl = ""
   await Promise.all(dispatches);
 }
 
-const ModelNavigator = ({ modelUrl, propsUrl, readMeUrl, changelogUrl }) => {
+const ModelNavigator = ({ modelUrl, propsUrl, readMeUrl, changelogUrl, pdfDownloadEnabled }) => {
   const [store, setStore] = React.useState(buildStore());
 
   useEffect(() => {
     const newStore = buildStore();
 
     setStore(newStore);
-    populateStore(newStore, modelUrl, propsUrl, readMeUrl, changelogUrl);
-  }, [modelUrl, propsUrl, changelogUrl, readMeUrl]);
+    populateStore(newStore, modelUrl, propsUrl, readMeUrl, changelogUrl, pdfDownloadEnabled);
+  }, [modelUrl, propsUrl, changelogUrl, readMeUrl, pdfDownloadEnabled]);
 
   return (
     <Provider store={store}>
-      <ReduxDataDictionary pdfDownloadConfig={pdfDownloadConfig} />
+      <ReduxDataDictionary />
     </Provider >
   );
 };

--- a/src/stories/ModelNavigator.stories.jsx
+++ b/src/stories/ModelNavigator.stories.jsx
@@ -6,6 +6,11 @@ export default {
   component: ModelNavigator,
   parameters: {},
   argTypes: {
+    pdfDownloadEnabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
     modelUrl: {
       control: {
         type: 'text',
@@ -34,6 +39,7 @@ const Template = (args) => <ModelNavigator {...args} />;
 export const Navigator = Template.bind({});
 
 Navigator.args = {
+  pdfDownloadEnabled: true,
   modelUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/6.0.2/cds-model.yml",
   propsUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/6.0.2/cds-model-props.yml",
   readMeUrl: "https://raw.githubusercontent.com/CBIIT/crdc-datahub-models/dev2/cache/CDS/6.0.2/README.md",


### PR DESCRIPTION
### Overview

Added an opt-in feature for configuring the visibility of download buttons. No changes necessary if not using this feature

### Change Details (Specifics)

- By default enable download button visibility, making this an opt-in feature
- Hide download buttons in the header and within each of the nodes
- Add storybook support for toggling visibility

### Related Ticket(s)

[DMN-16](https://essential-soft.atlassian.net/browse/DMN-16)