### PR TITLE
CTDC-1719: add ancestor node traceback feature

### DIFF
--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
@@ -38,7 +38,8 @@ const CanvasController = ({
   highlightedNodes,
   graphViewConfig,
   onGraphPanelClick,
-  assetConfig
+  assetConfig,
+  ancestorFilterNodeIds
 }) => {
     if (tabViewWidth === 0 || !graphViewConfig) {
       return <CircularProgress />;
@@ -106,6 +107,7 @@ const CanvasController = ({
      * update states
      * 1. nodes and edges
      * 2. toggle between on/off for serach mode
+     * 3. filter nodes/edges based on ancestor filter
      */
     useEffect(() => {
         const flowData = createNodesAndEdges({dictionary}, true, []);
@@ -113,9 +115,21 @@ const CanvasController = ({
             flowData.nodes,
             flowData.edges,
         );
-        setNodes(layoutedNodes);
-        setEdges(layoutedEdges);
-    }, [dictionary, currentSearchKeyword]);
+        
+        if (ancestorFilterNodeIds) {
+            const filteredNodes = layoutedNodes.filter(node => 
+                ancestorFilterNodeIds.has(node.id)
+            );
+            const filteredEdges = layoutedEdges.filter(edge => 
+                ancestorFilterNodeIds.has(edge.source) && ancestorFilterNodeIds.has(edge.target)
+            );
+            setNodes(filteredNodes);
+            setEdges(filteredEdges);
+        } else {
+            setNodes(layoutedNodes);
+            setEdges(layoutedEdges);
+        }
+    }, [dictionary, currentSearchKeyword, ancestorFilterNodeIds]);
 
     const onConnect = useCallback(
       (params) =>
@@ -156,11 +170,15 @@ const mapStateToProps = (state) => ({
     unfilteredDictionary: state.submission.unfilteredDictionary,
     graphViewConfig: state.ddgraph.graphViewConfig,
     assetConfig: state.ddgraph.assetConfig,
+    ancestorFilterNodeIds: state.ddgraph.ancestorFilterNodeIds,
 });
 
 const mapDispatchToProps = (dispatch) => ({
   setGraphData: (graphData) => {dispatch(setReactFlowGraphData(graphData))},
-  onGraphPanelClick: () => {dispatch(onPanelViewClick())},
+  onGraphPanelClick: () => {
+    dispatch(onPanelViewClick());
+    dispatch({ type: 'CLEAR_ANCESTOR_FILTER' });
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CanvasController);

--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
@@ -129,7 +129,7 @@ const CanvasController = ({
     /**
      * update states
      * 1. nodes and edges
-     * 2. toggle between on/off for serach mode
+     * 2. toggle between on/off for search mode
      * 3. filter nodes/edges based on ancestor filter
      */
     useEffect(() => {

--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasController.jsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import {
     addEdge,
+  applyNodeChanges,
     useNodesState,
     useEdgesState,
 } from 'reactflow';
@@ -45,9 +46,26 @@ const CanvasController = ({
       return <CircularProgress />;
     }
 
-    const [nodes, setNodes, onNodesChange] = useNodesState([]);
+    const [nodes, setNodes] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
     const [categories, setCategories] = useState([]);
+    const nodePositionsRef = useRef({});
+
+    const cacheNodePositions = useCallback((nodeList) => {
+      nodeList.forEach((node) => {
+        if (node?.id && node?.position) {
+          nodePositionsRef.current[node.id] = node.position;
+        }
+      });
+    }, []);
+
+    const onNodesChange = useCallback((changes) => {
+      setNodes((currentNodes) => {
+        const updatedNodes = applyNodeChanges(changes, currentNodes);
+        cacheNodePositions(updatedNodes);
+        return updatedNodes;
+      });
+    }, [setNodes, cacheNodePositions]);
 
     /**
      * initalize category item for Legend
@@ -93,6 +111,11 @@ const CanvasController = ({
             if(!node.data.icon) {
               node.data.icon = DefaultIcon.svg;
             }
+            const persistedPosition = nodePositionsRef.current[node.id];
+            if (persistedPosition) {
+              node.position = persistedPosition;
+              return;
+            }
             const position = nodePosition[node.id];
             node.position = {
               x: position[0],
@@ -125,11 +148,13 @@ const CanvasController = ({
             );
             setNodes(filteredNodes);
             setEdges(filteredEdges);
+            cacheNodePositions(filteredNodes);
         } else {
             setNodes(layoutedNodes);
             setEdges(layoutedEdges);
+            cacheNodePositions(layoutedNodes);
         }
-    }, [dictionary, currentSearchKeyword, ancestorFilterNodeIds]);
+      }, [dictionary, currentSearchKeyword, ancestorFilterNodeIds, setNodes, setEdges, cacheNodePositions]);
 
     const onConnect = useCallback(
       (params) =>

--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasHelper.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Canvas/CanvasHelper.jsx
@@ -174,3 +174,60 @@ export const getNodePosition = ({
     return position;
 }
 
+/**
+ * Build a map of child nodes to their parent nodes from dictionary
+ * @param {object} dictionary - The complete dictionary
+ * @returns {object} Map of { childNodeId: [parentNodeId1, parentNodeId2, ...] }
+ */
+export const buildParentMap = (dictionary) => {
+    const parentMap = {};
+    
+    Object.keys(dictionary).forEach(nodeId => {
+        const node = dictionary[nodeId];
+        if (node.links && Array.isArray(node.links)) {
+            node.links.forEach(link => {
+                const childNode = link.backref;
+                const parentNode = link.name;
+                
+                if (childNode && parentNode && childNode !== parentNode) {
+                    if (!parentMap[childNode]) {
+                        parentMap[childNode] = [];
+                    }
+                    if (!parentMap[childNode].includes(parentNode)) {
+                        parentMap[childNode].push(parentNode);
+                    }
+                }
+            });
+        }
+    });
+    
+    return parentMap;
+};
+
+/**
+ * Get all ancestor nodes (parents, grandparents, etc.) from a starting node up to root nodes
+ * @param {string} nodeId - The starting node ID
+ * @param {object} parentMap - Map of child to parent relationships
+ * @returns {Set} Set of all ancestor node IDs including the starting node
+ */
+export const getAncestorNodes = (nodeId, parentMap) => {
+    const ancestors = new Set([nodeId]);
+    const queue = [nodeId];
+    const visited = new Set([nodeId]);
+    
+    while (queue.length > 0) {
+        const currentNode = queue.shift();
+        const parents = parentMap[currentNode] || [];
+        
+        parents.forEach(parentId => {
+            if (!visited.has(parentId)) {
+                ancestors.add(parentId);
+                queue.push(parentId);
+                visited.add(parentId);
+            }
+        });
+    }
+    
+    return ancestors;
+};
+

--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Node/NodeView.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Node/NodeView.jsx
@@ -24,6 +24,7 @@ const NodeView = ({
   onNodeFocus,
   focusedNodeId,
   iconMapInfo,
+  onClearAncestorFilter,
 }) => {
   const [display, setDisplay] = useState(false);
   /**
@@ -36,6 +37,7 @@ const NodeView = ({
     setDisplay(!display);
     if (display) {
       onCollapseNodeView();
+      onClearAncestorFilter();
     }
   };
   const {

--- a/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Node/ReduxNodeView.jsx
+++ b/src/components/ModelNavigator/DataDictionary/ReactFlowGraph/Node/ReduxNodeView.jsx
@@ -19,7 +19,8 @@ const mapDispatchToProps = (dispatch) => ({
   onClickNode: (nodeID) => dispatch(clickNode(nodeID)),
   onNodeFocus: (nodeID) => dispatch(focusNode(nodeID)),
   onViewTable: (hide) => dispatch(setOverlayPropertyTableHidden(hide)),
-  onCollapseNodeView: () => {dispatch(onPanelViewClick())}
+  onCollapseNodeView: () => {dispatch(onPanelViewClick())},
+  onClearAncestorFilter: () => dispatch({ type: 'CLEAR_ANCESTOR_FILTER' }),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ReduxNodeView);

--- a/src/components/ModelNavigator/DataDictionary/Store/actions/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/actions/graph.js
@@ -156,11 +156,11 @@ export const onNodeDragStart = () => ({
 });
 
 export const setAncestorFilter = (ancestorNodeIds) => ({
-  type: 'SET_ANCESTOR_FILTER',
+  type: actionTypes.SET_ANCESTOR_FILTER,
   ancestorNodeIds,
 });
 
 export const clearAncestorFilter = () => ({
-  type: 'CLEAR_ANCESTOR_FILTER',
+  type: actionTypes.CLEAR_ANCESTOR_FILTER,
 });
 

--- a/src/components/ModelNavigator/DataDictionary/Store/actions/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/actions/graph.js
@@ -155,3 +155,12 @@ export const onNodeDragStart = () => ({
   type: actionTypes.ON_REACT_FLOW_NODE_DRAG_START,
 });
 
+export const setAncestorFilter = (ancestorNodeIds) => ({
+  type: 'SET_ANCESTOR_FILTER',
+  ancestorNodeIds,
+});
+
+export const clearAncestorFilter = () => ({
+  type: 'CLEAR_ANCESTOR_FILTER',
+});
+

--- a/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
@@ -4,7 +4,7 @@ import {
   clearSearchHistoryItems,
   addSearchHistoryItems,
   onViewChange,
-  onCnavasWidthChange,
+  onCanvasWidthChange,
 } from '../../Utils/utils';
 import * as actionTypes from '../actions/actionTypes';
 import { buildParentMap, getAncestorNodes } from '../../ReactFlowGraph/Canvas/CanvasHelper';
@@ -381,7 +381,7 @@ const ddgraph = (state = ddgraphInitialState, action) => {
     case actionTypes.CNAVAS_WIDTH_CHANGE:
       return {
         ...state,
-        graphViewConfig: onCnavasWidthChange({...action, ...state}),
+        graphViewConfig: onCanvasWidthChange({...action, ...state}),
       }
     case 'SET_ANCESTOR_FILTER':
       return {

--- a/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
+++ b/src/components/ModelNavigator/DataDictionary/Store/reducers/graph.js
@@ -7,6 +7,7 @@ import {
   onCnavasWidthChange,
 } from '../../Utils/utils';
 import * as actionTypes from '../actions/actionTypes';
+import { buildParentMap, getAncestorNodes } from '../../ReactFlowGraph/Canvas/CanvasHelper';
 
 const ddgraphInitialState = {
   isGraphView: true,
@@ -37,6 +38,7 @@ const ddgraphInitialState = {
   highlightingMatchedNodeOpened: false,
   dictionary: {},
   pdfDownloadConfig: { enabled: true },
+  ancestorFilterNodeIds: null, // Set of node IDs to show (null = show all)
 };
 
 const ddgraph = (state = ddgraphInitialState, action) => {
@@ -162,7 +164,9 @@ const ddgraph = (state = ddgraphInitialState, action) => {
           highlightedNodes: newArray,
         };
       }
-      // if serach mode is false
+      const parentMap = buildParentMap(state.dictionary);
+      const ancestorNodeIds = getAncestorNodes(action.nodeID, parentMap);
+      
       return {
         ...state,
           highlightingMatchedNodeID: action.nodeID,
@@ -171,6 +175,7 @@ const ddgraph = (state = ddgraphInitialState, action) => {
           overlayPropertyHidden: true,
           expandNodeView: true,
           highlightedNodes: newArray,
+          ancestorFilterNodeIds: ancestorNodeIds,
       }
     }
     case 'GRAPH_CLICK_NODE': {
@@ -378,6 +383,19 @@ const ddgraph = (state = ddgraphInitialState, action) => {
         ...state,
         graphViewConfig: onCnavasWidthChange({...action, ...state}),
       }
+    case 'SET_ANCESTOR_FILTER':
+      return {
+        ...state,
+        ancestorFilterNodeIds: action.ancestorNodeIds,
+      };
+    case 'CLEAR_ANCESTOR_FILTER':
+      return {
+        ...state,
+        ancestorFilterNodeIds: null,
+        expandNodeView: false,
+        highlightingNode: null,
+        overlayPropertyHidden: true,
+      };
     default:
       return state;
   }

--- a/src/components/ModelNavigator/DataDictionary/Utils/utils.js
+++ b/src/components/ModelNavigator/DataDictionary/Utils/utils.js
@@ -255,7 +255,7 @@ export const onViewChange = (payload) => {
   return payload;
 }
 
-export const onCnavasWidthChange = ({ canvasWidth, graphViewConfig}) => {
+export const onCanvasWidthChange = ({ canvasWidth, graphViewConfig}) => {
   const updateGraphViewConfig = _.cloneDeep(graphViewConfig);
   if (updateGraphViewConfig) {
     updateGraphViewConfig.canvas.width = canvasWidth;


### PR DESCRIPTION
- Clicking a node filters the graph to show only that node and its parent path to root
- Filter clears when closing node or clicking canvas
- Uses Redux state and BFS traversal to find ancestors